### PR TITLE
Update README.md to reflect repository ownership and change testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install jpy-tools
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/yourusername/jpy-tools.git
+git clone https://github.com/jim-schilling/jpy-tools.git
 cd jpy-tools
 ```
 
@@ -55,9 +55,9 @@ pip install -e .
 
 ### Testing
 
-Run tests using pytest:
+Run tests using unittest:
 ```bash
-pytest tests/
+python -m unittest discover tests/
 ```
 
 ## License


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect changes in the repository URL and testing instructions.

Repository URL update:
* Updated the Git clone command to use the new repository URL (`https://github.com/jim-schilling/jpy-tools.git`).

Testing instructions update:
* Changed the recommended testing framework from `pytest` to `unittest` and updated the corresponding command (`python -m unittest discover tests/`).